### PR TITLE
Bind input `value` to bindable `value` Input property

### DIFF
--- a/src/lib/input/input.svelte
+++ b/src/lib/input/input.svelte
@@ -159,7 +159,7 @@
 			<div class="w-full h-full {inputContClass}">
 				<input
 					{type}
-					{value}
+					bind:value
 					aria-labelledby={araiLabelledBy}
 					{spellcheck}
 					{placeholder}


### PR DESCRIPTION
## Quick Glance

- Change `{value}` to `bind:value` in `src/lib/input/input.svelte`.
  Fixes #12

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Wombosvideo/kampsy-ui?shareId=61c22212-3a6f-47ec-97d8-c9ce63a03301).